### PR TITLE
Updated 'prettier' from 2.2.1 to 2.5.1 (latest). `yarn test:unit` pas…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,10 @@
-name: CI
+name: Continuous Integration
 
+# This action works with pull requests and pushes
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -35,6 +35,10 @@ jobs:
           yarn install
           yarn global add npm-publish
 
+      - name: Prettify code
+        run: |
+          echo "Prettifying code"
+          yarn fix:prettier
 
       - name: install dependencies for fixtures
         run: |
@@ -53,4 +57,4 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./docs
-          commit_message: "[ci skip] Updates"
+          commit_message: '[ci skip] Updates'

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jest": "^27.4.7",
     "npm-run-all": "^4.1.5",
     "open-cli": "^6.0.1",
-    "prettier": "^2.1.1",
+    "prettier": "^2.5.1",
     "standard-version": "^9.3.2",
     "ts-jest": "^27.1.2",
     "ts-node": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5944,10 +5944,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
…sed. `yarn test` wont pass because it checks if all the code is pretty, but with the update, prettier wants to prettify it with it's new rules. That's why there is also a change in '.github/workflows/CI.yml': prettier will do it's job on the server side before one can accept any pull-request from now on.

Hope it works!